### PR TITLE
Enhancement: add specialization for zend_uintptr_t to int32_t map.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -62,7 +62,7 @@ if test "$PHP_IGBINARY" != "no"; then
 
   PHP_ADD_MAKEFILE_FRAGMENT(Makefile.bench)
   PHP_INSTALL_HEADERS([ext/igbinary], [igbinary.h])
-  PHP_NEW_EXTENSION(igbinary, igbinary.c hash_si.c, $ext_shared,, $PHP_IGBINARY_CFLAGS)
+  PHP_NEW_EXTENSION(igbinary, igbinary.c hash_si.c hash_si_ptr.c, $ext_shared,, $PHP_IGBINARY_CFLAGS)
   PHP_ADD_EXTENSION_DEP(igbinary, session, true)
   PHP_SUBST(IGBINARY_SHARED_LIBADD)
 fi

--- a/config.w32
+++ b/config.w32
@@ -8,7 +8,7 @@ if (PHP_IGBINARY == "yes") {
   if (res) {
     AC_DEFINE('HAVE_APC_SUPPORT', 1, 'Whether to enable apc support')
   }
-  EXTENSION("igbinary", "igbinary.c hash_si.c");
+  EXTENSION("igbinary", "igbinary.c hash_si.c hash_si_ptr.c");
   AC_DEFINE('HAVE_IGBINARY', 1, 'Have igbinary support', false);
   ADD_EXTENSION_DEP('igbinary', 'session');
 }

--- a/hash_ptr.h
+++ b/hash_ptr.h
@@ -1,0 +1,100 @@
+/*
+  +----------------------------------------------------------------------+
+  | See COPYING file for further copyright information                   |
+  +----------------------------------------------------------------------+
+  | Author: Oleg Grenrus <oleg.grenrus@dynamoid.com>                     |
+  | See CREDITS for contributors                                         |
+  | This is like hash.h, but the key is always a zend_uintptr_t			 |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef HASH_PTR_H
+#define HASH_PTR_H
+
+#include <assert.h>
+
+#ifdef PHP_WIN32
+# include "ig_win32.h"
+#else
+# include <stdint.h>     /* defines uint32_t etc */
+#endif
+
+#include <stddef.h>
+#include "zend_types.h"
+
+// NULL converted to an integer, on sane platforms.
+#define HASH_PTR_KEY_INVALID 0
+
+/** Key/value pair of hash_si_ptr.
+ * @author Oleg Grenrus <oleg.grenrus@dynamoid.com>
+ * @see hash_si_ptr
+ */
+struct hash_si_ptr_pair
+{
+	zend_uintptr_t key; /**< The key: The address of a pointer, casted to an int (won't be dereferenced). */
+	uint32_t value;		/**< Value. */
+};
+
+/** Hash-array.
+ * Like c++ std::unordered_map<zend_uintptr_t, int32_t>, but does not allow HASH_PTR_KEY_INVALID as a key.
+ * Current implementation uses linear probing.
+ * @author Oleg Grenrus <oleg.grenrus@dynamoid.com>
+ */
+struct hash_si_ptr {
+	size_t size; 					/**< Allocated size of array. */
+	size_t used;					/**< Used size of array. */
+	struct hash_si_ptr_pair *data;		/**< Pointer to array or pairs of data. */
+};
+
+/** Inits hash_si_ptr structure.
+ * @param h pointer to hash_si_ptr struct.
+ * @param size initial size of the hash array.
+ * @return 0 on success, 1 else.
+ */
+int hash_si_ptr_init(struct hash_si_ptr *h, size_t size);
+
+/** Frees hash_si_ptr structure.
+ * Doesn't call free(h).
+ * @param h pointer to hash_si_ptr struct.
+ */
+void hash_si_ptr_deinit(struct hash_si_ptr *h);
+
+/** Inserts value into hash_si_ptr.
+ * @param h Pointer to hash_si_ptr struct.
+ * @param key Pointer to key.
+ * @param key_len Key length.
+ * @param value Value.
+ * @return 0 on success, 1 or 2 else.
+ */
+int hash_si_ptr_insert (struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t value);
+
+/** Finds value from hash_si_ptr.
+ * Value returned thru value param.
+ * @param h Pointer to hash_si_ptr struct.
+ * @param key Pointer to key.
+ * @param key_len Key length.
+ * @param[out] value Found value.
+ * @return 0 if found, 1 if not.
+ */
+int hash_si_ptr_find (struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t * value);
+
+/** Travarses hash_si_ptr.
+ * Calls traverse_function on every item. Traverse function should not modify hash
+ * @param h Pointer to hash_si_ptr struct.
+ * @param traverse_function Function to call on every item of hash_si_ptr.
+ */
+void hash_si_ptr_traverse (struct hash_si_ptr *h, int (*traverse_function) (const zend_uintptr_t key, uint32_t value));
+
+/** Returns size of hash_si_ptr.
+ * @param h Pointer to hash_si_ptr struct.
+ * @return Size of hash_si_ptr.
+ */
+size_t hash_si_ptr_size (struct hash_si_ptr *h);
+
+/** Returns capacity of hash_si_ptr.
+ * @param h Pointer to hash_si_ptr struct.
+ * @return Capacity of hash_si_ptr.
+ */
+size_t hash_si_ptr_capacity (struct hash_si_ptr *h);
+
+#endif /* HASH_PTR_H */

--- a/hash_ptr.h
+++ b/hash_ptr.h
@@ -4,7 +4,8 @@
   +----------------------------------------------------------------------+
   | Author: Oleg Grenrus <oleg.grenrus@dynamoid.com>                     |
   | See CREDITS for contributors                                         |
-  | This is like hash.h, but the key is always a zend_uintptr_t			 |
+  | This defines hash_si_ptr.                                            |
+  | It is like hash_si, but the key is always a non-zero zend_uintptr_t  |
   +----------------------------------------------------------------------+
 */
 
@@ -77,13 +78,6 @@ int hash_si_ptr_insert (struct hash_si_ptr *h, const zend_uintptr_t key, uint32_
  * @return 0 if found, 1 if not.
  */
 int hash_si_ptr_find (struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t * value);
-
-/** Travarses hash_si_ptr.
- * Calls traverse_function on every item. Traverse function should not modify hash
- * @param h Pointer to hash_si_ptr struct.
- * @param traverse_function Function to call on every item of hash_si_ptr.
- */
-void hash_si_ptr_traverse (struct hash_si_ptr *h, int (*traverse_function) (const zend_uintptr_t key, uint32_t value));
 
 /** Returns size of hash_si_ptr.
  * @param h Pointer to hash_si_ptr struct.

--- a/hash_si_ptr.c
+++ b/hash_si_ptr.c
@@ -23,7 +23,7 @@
 #include "zend.h"
 
 /* Function similar to zend_inline_hash_func. This is not identical. */
-inline uint32_t inline_hash_of_address(zend_uintptr_t ptr) {
+inline static uint32_t inline_hash_of_address(zend_uintptr_t ptr) {
 	register uint32_t hash = Z_UL(5381);
 	/* Note: Hash the least significant bytes first - Those need to influence the final result as much as possible. */
 	hash = ((hash << 5) + hash) + (ptr & 0xff);

--- a/hash_si_ptr.c
+++ b/hash_si_ptr.c
@@ -1,0 +1,197 @@
+/*
+  +----------------------------------------------------------------------+
+  | See COPYING file for further copyright information                   |
+  | This is a specialized hash map mapping uintprt_t to int32_t          |
+  +----------------------------------------------------------------------+
+  | Author: Oleg Grenrus <oleg.grenrus@dynamoid.com>                     |
+  | Modified by Tyson Andre for fixed size, removing unused functions    |
+  | See CREDITS for contributors                                         |
+  +----------------------------------------------------------------------+
+*/
+
+#ifdef PHP_WIN32
+# include "ig_win32.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <assert.h>
+
+#include "hash_ptr.h"
+#include "zend.h"
+
+/* Function similar to zend_inline_hash_func. This is not identical. */
+inline uint32_t inline_hash_of_address(zend_uintptr_t ptr) {
+	register uint32_t hash = Z_UL(5381);
+	/* Note: Hash the least significant bytes first - Those need to influence the final result as much as possible. */
+	hash = ((hash << 5) + hash) + (ptr & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 8) & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 16) & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 24) & 0xff);
+#if SIZEOF_ZEND_LONG == 8
+	hash = ((hash << 5) + hash) + ((ptr >> 32) & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 40) & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 48) & 0xff);
+	hash = ((hash << 5) + hash) + ((ptr >> 56) & 0xff);
+#endif
+	return hash;
+}
+
+/* {{{ nextpow2 */
+/** Next power of 2.
+ * @param n Integer.
+ * @return next to n power of 2 .
+ */
+inline static uint32_t nextpow2(uint32_t n) {
+	uint32_t m = 1;
+	while (m < n) {
+		m = m << 1;
+	}
+
+	return m;
+}
+/* }}} */
+/* {{{ hash_si_ptr_init */
+int hash_si_ptr_init(struct hash_si_ptr *h, size_t size) {
+	size = nextpow2(size);
+
+	h->size = size;
+	h->used = 0;
+	h->data = (struct hash_si_ptr_pair*) malloc(sizeof(struct hash_si_ptr_pair) * size);
+	if (h->data == NULL) {
+		return 1;
+	}
+
+	memset(h->data, 0, sizeof(struct hash_si_ptr_pair) * size); /* Set everything to 0. sets keys to HASH_PTR_KEY_INVALID. */
+
+	return 0;
+}
+/* }}} */
+/* {{{ hash_si_ptr_deinit */
+void hash_si_ptr_deinit(struct hash_si_ptr *h) {
+	size_t i;
+
+	free(h->data);
+	h->data = NULL;
+
+	h->size = 0;
+	h->used = 0;
+}
+/* }}} */
+/* {{{ _hash_si_ptr_find */
+/** Returns index of key, or where it should be.
+ * @param h Pointer to hash_si_ptr struct.
+ * @param key Pointer to key.
+ * @return index.
+ */
+inline static size_t _hash_si_ptr_find(struct hash_si_ptr *h, const zend_uintptr_t key) {
+	uint32_t hv;
+	size_t size;
+
+	assert(h != NULL);
+
+	size = h->size;
+	hv = inline_hash_of_address(key) & (h->size-1);
+
+	while (size > 0 &&
+		h->data[hv].key != HASH_PTR_KEY_INVALID &&
+		h->data[hv].key != key) {
+		/* linear prob */
+		hv = (hv + 1) & (h->size-1);
+		size--;
+	}
+
+	return hv;
+}
+/* }}} */
+/* }}} */
+/* {{{ hash_si_ptr_rehash */
+/** Rehash/resize hash_si_ptr.
+ * @param h Pointer to hash_si_ptr struct.
+ */
+inline static void hash_si_ptr_rehash(struct hash_si_ptr *h) {
+	uint32_t hv;
+	size_t i;
+	struct hash_si_ptr newh;
+
+	assert(h != NULL);
+
+	hash_si_ptr_init(&newh, h->size * 2);
+
+	for (i = 0; i < h->size; i++) {
+		if (h->data[i].key != HASH_PTR_KEY_INVALID) {
+			hv = _hash_si_ptr_find(&newh, h->data[i].key);
+			newh.data[hv].key = h->data[i].key;
+			newh.data[hv].value = h->data[i].value;
+		}
+	}
+
+	free(h->data);
+	h->data = newh.data;
+	h->size *= 2;
+}
+/* }}} */
+/* {{{ hash_si_ptr_insert */
+int hash_si_ptr_insert(struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t value) {
+	uint32_t hv;
+
+	if (h->size / 4 * 3 < h->used + 1) {
+		hash_si_ptr_rehash(h);
+	}
+
+	hv = _hash_si_ptr_find(h, key);
+
+	if (h->data[hv].key == HASH_PTR_KEY_INVALID) {
+		h->data[hv].key = key;
+
+		h->used++;
+	} else {
+		return 2;
+	}
+
+	h->data[hv].value = value;
+
+	return 0;
+}
+/* }}} */
+/* {{{ hash_si_ptr_find */
+int hash_si_ptr_find(struct hash_si_ptr *h, const zend_uintptr_t key, uint32_t *value) {
+	uint32_t hv;
+
+	assert(h != NULL);
+
+	hv = _hash_si_ptr_find(h, key);
+
+	if (h->data[hv].key == HASH_PTR_KEY_INVALID) {
+		return 1;
+	} else {
+		*value = h->data[hv].value;
+		return 0;
+	}
+}
+/* }}} */
+/* {{{ hash_si_ptr_size */
+size_t hash_si_ptr_size(struct hash_si_ptr *h) {
+	assert(h != NULL);
+
+	return h->used;
+}
+/* }}} */
+/* {{{ hash_si_ptr_capacity */
+size_t hash_si_ptr_capacity(struct hash_si_ptr *h) {
+	assert(h != NULL);
+
+	return h->size;
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 2
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,8 @@
    <file name="config.w32" role="src" />
    <file name="hash.h" role="src" />
    <file name="hash_si.c" role="src" />
+   <file name="hash_ptr.h" role="src" />
+   <file name="hash_si_ptr.c" role="src" />
    <file name="igbinary.c" role="src" />
    <file name="igbinary.h" role="src" />
    <file name="php_igbinary.h" role="src" />


### PR DESCRIPTION
This map is used for generating the reference ids in the serialization
output.

Consistently use zend types. Fix documentation (From igbinary#15)

benchmark/serialize-objectarray.b.php had the time go down from
1.22 to 1.05 seconds (with default CFLAGS)
benchmark/serialize-stringarray.b.php was unaffected.

Unserialization is unaffected; it doesn't use this data structure.

This is much more efficient, since it
- uses less memory (a zend_uintptr_t, used to be char\* + length + contents of char*)
- Avoids allocation/deallocation, and pointer dereferencing.
